### PR TITLE
Fix classloader usage to support Java 9

### DIFF
--- a/src/boot/bin/ParentClassLoader.java
+++ b/src/boot/bin/ParentClassLoader.java
@@ -1,0 +1,13 @@
+package boot.bin;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+
+// Exists solely so we have a type to seal to prevent user code from
+// altering our top-level CL.
+public class ParentClassLoader extends URLClassLoader {
+    public ParentClassLoader(ClassLoader parent) {
+        super(new URL[0], parent); }
+
+    public void addURL(URL url) {
+	super.addURL(url); }}


### PR DESCRIPTION
The changes here include:

* don't assume the system classloader is a URLClassLoader (it isn't
  under Java 9)
* insert a classloader we control into the loader chain so we can have
  one to modify
* use our own subclass of URLClassLoader that exposes .addURL, so we can
  modify it (we can't call .setAccessible on .addURL under Java 9)

Fixes #525

There are more changes required in boot-clj/boot, PR coming directly.