### PR TITLE
WIP: Fetch from Clojars & better SNAPSHOT support

### DIFF
--- a/src/Boot.java
+++ b/src/Boot.java
@@ -182,7 +182,17 @@ public class Boot {
 
     public static String
     downloadUrl(String version, String name) throws Exception {
-        return String.format("https://github.com/boot-clj/boot/releases/download/%s/%s", version, name); }
+        // FEATURE FLAG - Enabling this will all cause all non-snapshot
+        // releases from 2.8 onwards to be downloaded from Clojars
+        Boolean clojarsDownloadEnabled = false;
+        if (clojarsDownloadEnabled &&
+            0 < version.compareTo("2.8") &&
+            !version.endsWith("SNAPSHOT") &&
+            name.equals("boot.jar")) {
+            String urlFormat = "https://repo.clojars.org/boot/base/%s/base-%s-uber.jar";
+            return String.format(urlFormat, version, version);
+        } else { // 2.7.2 and lower download releases from github
+            return String.format("https://github.com/boot-clj/boot/releases/download/%s/%s", version, name); }}
 
     public static File
     validateBinaryFile(File f) throws Exception {


### PR DESCRIPTION
This is still very much a work in progress but opening a PR for feedback.

Some of the motivation for this has been outlined in https://github.com/boot-clj/boot-bin/issues/6

Besides speed this will also greatly simplify the release process of SNAPSHOTs.

Currently whenever a SNAPSHOT release is being cut we need to create a release on Github. This in itself is a bit of manual labor but fine. The problem is that Github releases are thought of as immutable. You can update files attached to a release but nobody will notice.

This makes it hard for Boot maintainers to ship development builds, making it harder for people to test those etc.pp.

If you believe we shouldn't be using SNAPSHOTs at all chat me up in `#boot-dev` on Slack. I've thought how we could use proper releases but couldn't come up with an approach that would keep `boot -u` work as it currently does.

One Caveat/Feature: If you're running a SNAPSHOT it won't update automatically.  You'll need to remove the respective files in `~/.boot/cache/bin/$VERSION` to trigger a redownload of the updated SNAPSHOT.