### PR TITLE
Read boot.properties in boot script

### DIFF
--- a/src/head.sh
+++ b/src/head.sh
@@ -1,6 +1,41 @@
 #!/usr/bin/env bash
-declare -a "options=($BOOT_JVM_OPTIONS)"
+
+set -euo pipefail
+
+process_properties() {
+    if [[ -f "$1" ]]; then
+        while IFS='=' read -r key value; do
+            if [[ -n "$value" ]]; then
+                if [[ "$key" == "BOOT_JAVA_COMMAND" ]]; then
+                    java_command="$value"
+                elif [[ "$key" == "BOOT_JVM_OPTIONS" ]]; then
+                    options=($value)
+                fi
+            fi
+        done < "$1"
+    fi
+}
+
+# defaults
+
+java_command=java
+declare -a options=(${BOOT_JVM_OPTIONS-})
+
+# process properties files
+
+process_properties "${BOOT_HOME:-$HOME/.boot}/boot.properties"
+process_properties "boot.properties"
+
+# environment variables take precdence
+
+if [[ -n "${BOOT_JAVA_COMMAND-}" ]]; then
+    java_command="$BOOT_JAVA_COMMAND"
+fi
+if [[ -n "${BOOT_JVM_OPTIONS-}" ]]; then
+    options=($BOOT_JVM_OPTIONS)
+fi
+
 self="${BASH_SOURCE[0]}"
 selfdir="$(cd "$(dirname "${self}")" ; pwd)"
 selfpath="$selfdir/$(basename "$self")"
-exec ${BOOT_JAVA_COMMAND:-java} "${options[@]}" -Dboot.app.path="$selfpath" -jar "$0" "$@"
+exec "$java_command" "${options[@]}" -Dboot.app.path="$selfpath" -jar "$0" "$@"

--- a/src/head.sh
+++ b/src/head.sh
@@ -38,4 +38,4 @@ fi
 self="${BASH_SOURCE[0]}"
 selfdir="$(cd "$(dirname "${self}")" ; pwd)"
 selfpath="$selfdir/$(basename "$self")"
-exec "$java_command" "${options[@]}" -Dboot.app.path="$selfpath" -jar "$0" "$@"
+exec "$java_command" "${options[@]-}" -Dboot.app.path="$selfpath" -jar "$0" "$@"

--- a/src/head.sh
+++ b/src/head.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 process_properties() {
     if [[ -f "$1" ]]; then
-        while IFS='=' read -r key value; do
+        while IFS='=' read -r key value || [[ -n "$key" ]]; do
             if [[ -n "$value" ]]; then
                 if [[ "$key" == "BOOT_JAVA_COMMAND" ]]; then
                     java_command="$value"


### PR DESCRIPTION
Alternative implementation of #5, solution to https://github.com/boot-clj/boot/issues/433

This avoids using `eval` by parsing boot.properties manually.
  